### PR TITLE
Updated README and requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# VIRTUALENV #
+bin/*
+include/*
+lib/*
+pip-selfcheck.json
+share/
+source_me.sh
+src/models/__pycache__/*

--- a/README.md
+++ b/README.md
@@ -40,16 +40,16 @@ echo "export CONFIGYAML=config/config.yml.template" >> source_me.sh
 source source_me.sh
 ```
 6. Download the data from kaggle
-  * Get a kaggle API token from your profile page (kaggle.com/username/account --> Create new API token)
-  * Copy the `kaggle.json` file to `$HOME/.kaggle`
-  ```bash
-  mkdir -f $HOME/.kaggle
-  mv $HOME/Downloads/kaggle.json $HOME/.kaggle/kaggle.json
-  chmod 600 $HOME/.kaggle/kaggle.json  # only you can read/write to it
-  ```
-  * Navigate to the project directory and un-zip the data
-  ```bash
-  kaggle datasets download -d paultimothymooney/denver-crime-data/version/25
-  mv denver-crime-data.zip data/raw
-  unzip denver-crime-data.zip`
-  ```
+ * Get a kaggle API token from your profile page (kaggle.com/username/account --> Create new API token)
+ * Copy the `kaggle.json` file to `$HOME/.kaggle`
+ ```bash
+ mkdir -f $HOME/.kaggle
+ mv $HOME/Downloads/kaggle.json $HOME/.kaggle/kaggle.json
+ chmod 600 $HOME/.kaggle/kaggle.json  # only you can read/write to it
+ ```
+ * Navigate to the project directory and un-zip the data
+ ```bash
+ kaggle datasets download -d paultimothymooney/denver-crime-data/version/25
+ mv denver-crime-data.zip data/raw
+ unzip denver-crime-data.zip`
+ ```

--- a/README.md
+++ b/README.md
@@ -11,21 +11,44 @@ This project analyzes data from the city of Denver, and can be found [here](http
 Because the data are updated regularly, we must choose a snapshot to ensure that everyone has the same data. We will be using version 25, which can be accessed at https://www.kaggle.com/paultimothymooney/denver-crime-data/version/25. Make sure you download this version, NOT the latest version.
 
 ## Getting started
-Please consult the [*Project setup*](https://github.com/the4thparadigm/hitchhikers_guide/tree/master/ds_projects/project_set_up) section of the hitchhiker's guide before proceeding. 
-* Clone this repo 
+Please consult the [*Project setup*](https://github.com/the4thparadigm/hitchhikers_guide/tree/master/ds_projects/project_set_up) section of the hitchhiker's guide before proceeding.
+* Clone this repo
+```bash
+git clone https://github.com/the4thparadigm/denvercrime.git
+```
+* Create a virtual environment called `venv` in the project root directory and activate it
+```bash
+virtualenv --python=python3 venv  # confirm any messages to create
+echo "source venv/bin/activate" >> source_me.sh
+source source_me.sh
+```
 * Create your own branch to work on
-* Create a virtual environment by running `virtualenv venv` in the project root directory. Activate it with `source venv\bin\activate`
-* Install packages from requirements.txt by running `pip3 install -r requirements.txt` in the project root directory
+```bash
+cd denvercrime
+git branch mybranch
+```
+* Install packages from requirements.txt using `pip` in the project root directory
+```bash
+pip3 install -r requirements.txt
+```
 * System environment
-  * Append the repo src folder to PYTHONPATH to allow module imports
+  * Update PYTHONPATH with the `src` folder/directory so python can import packages from `src`
   * Create environment variable that points to config file so python can find it
+```bash
+echo "export PYTHONPATH=src:$PYTHONPATH" >> source_me.sh
+echo "export CONFIGYAML=config/config.yml.template" >> source_me.sh
+source source_me.sh
+```
 * Download the data from kaggle
   * Get a kaggle API token from your profile page (kaggle.com/username/account --> Create new API token)
-  * In a terminal, navigate to your home directory
-  * `mkdir .kaggle`
-  * `mv Downloads/kaggle.json .kaggle/kaggle.json`
-  * Navigate to the project directory
-  * `kaggle datasets download -d paultimothymooney/denver-crime-data/version/25`
-  * `mv denver-crime-data.zip data/raw`
-  * `unzip denver-crime-data.zip`
-
+  * Copy the `kaggle.json` file to `$HOME/.kaggle`
+  ```bash
+  mkdir $HOME/.kaggle
+  mv $HOME/Downloads/kaggle.json $HOME/.kaggle/kaggle.json
+  ```
+  * Navigate to the project directory and un-zip the data
+  ```bash
+  kaggle datasets download -d paultimothymooney/denver-crime-data/version/25
+  mv denver-crime-data.zip data/raw
+  unzip denver-crime-data.zip`
+  ```

--- a/README.md
+++ b/README.md
@@ -12,26 +12,26 @@ Because the data are updated regularly, we must choose a snapshot to ensure that
 
 ## Getting started
 Please consult the [*Project setup*](https://github.com/the4thparadigm/hitchhikers_guide/tree/master/ds_projects/project_set_up) section of the hitchhiker's guide before proceeding.
-* Clone this repo
+1. Clone this repo
 ```bash
 git clone https://github.com/the4thparadigm/denvercrime.git
 ```
-* Create a virtual environment called `venv` in the project root directory and activate it
+2. Create a virtual environment called `venv` in the project root directory and activate it
 ```bash
 virtualenv --python=python3 venv  # confirm any messages to create
 echo "source venv/bin/activate" >> source_me.sh
 source source_me.sh
 ```
-* Create your own branch to work on
+3. Create your own branch to work on
 ```bash
 cd denvercrime
 git branch mybranch
 ```
-* Install packages from requirements.txt using `pip` in the project root directory
+4. Install packages from requirements.txt using `pip` in the project root directory
 ```bash
 pip3 install -r requirements.txt
 ```
-* System environment
+5. System environment
   * Update PYTHONPATH with the `src` folder/directory so python can import packages from `src`
   * Create environment variable that points to config file so python can find it
 ```bash
@@ -39,12 +39,13 @@ echo "export PYTHONPATH=src:$PYTHONPATH" >> source_me.sh
 echo "export CONFIGYAML=config/config.yml.template" >> source_me.sh
 source source_me.sh
 ```
-* Download the data from kaggle
+6. Download the data from kaggle
   * Get a kaggle API token from your profile page (kaggle.com/username/account --> Create new API token)
   * Copy the `kaggle.json` file to `$HOME/.kaggle`
   ```bash
-  mkdir $HOME/.kaggle
+  mkdir -f $HOME/.kaggle
   mv $HOME/Downloads/kaggle.json $HOME/.kaggle/kaggle.json
+  chmod 600 $HOME/.kaggle/kaggle.json  # only you can read/write to it
   ```
   * Navigate to the project directory and un-zip the data
   ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,6 +47,6 @@ tornado==4.5.3
 tqdm==4.31.0
 traitlets==4.3.2
 Unidecode==1.0.23
-urllib3==1.23
+urllib3==1.22
 wcwidth==0.1.7
 webencodings==0.5.1


### PR DESCRIPTION
When I ran 
```bash
pip3 install -r requirements.txt
```
I got that the version of urllib3 was the wrong version
```bash
kaggle 1.5.2 has requirement urllib3<1.23.0,>=1.15, but you'll have urllib3 1.23 which is incompatible.
```

so I changed urllib3 to version 1.22 which removed the message